### PR TITLE
Don’t let internal details leak

### DIFF
--- a/src/cf-metrics/main.go
+++ b/src/cf-metrics/main.go
@@ -54,9 +54,11 @@ type AppMetrics struct {
 }
 
 type Usage struct {
-	CPU  float64 `json:"cpu"`
-	Disk int64   `json:"disk"`
-	Mem  int64   `json:"mem"`
+	CPU       float64 `json:"cpu"`
+	Disk      int64   `json:"disk"`
+	Mem       int64   `json:"mem"`
+	DiskUsage float64 `json:"disk-usage"`
+	MemUsage  float64 `json:"mem-usage"`
 }
 
 type ContainerStats struct {

--- a/src/cf-metrics/main.go
+++ b/src/cf-metrics/main.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/cli/cf/api/appinstances"
 	"code.cloudfoundry.org/cli/cf/i18n"
 	"code.cloudfoundry.org/cli/cf/terminal"
 	"code.cloudfoundry.org/cli/cf/trace"
@@ -51,8 +50,26 @@ type Metric struct {
 
 type AppMetrics struct {
 	Metric
-	Stats appinstances.StatsAPIResponse
+	Stats Stats `json:"stats,omitempty"`
 }
+
+type Usage struct {
+	CPU  float64 `json:"cpu"`
+	Disk int64   `json:"disk"`
+	Mem  int64   `json:"mem"`
+}
+
+type ContainerStats struct {
+	DiskQuota int64 `json:"disk-quota"`
+	MemQuota  int64 `json:"mem-quota"`
+	Usage     Usage `json:"usage"`
+}
+
+type InstanceStats struct {
+	Stats ContainerStats `json:"stats"`
+}
+
+type Stats map[string]InstanceStats
 
 type EventInfo struct {
 	Type      string    `json:"type"`

--- a/src/cf-metrics/workers.go
+++ b/src/cf-metrics/workers.go
@@ -123,9 +123,11 @@ func cfStatsToExternalStats(stats appinstances.StatsAPIResponse) (res Stats) {
 				DiskQuota: v.Stats.DiskQuota,
 				MemQuota:  v.Stats.MemQuota,
 				Usage: Usage{
-					CPU:  v.Stats.Usage.CPU,
-					Disk: v.Stats.Usage.Disk,
-					Mem:  v.Stats.Usage.Mem,
+					CPU:       v.Stats.Usage.CPU,
+					Disk:      v.Stats.Usage.Disk,
+					Mem:       v.Stats.Usage.Mem,
+					DiskUsage: (float64(v.Stats.Usage.Disk) / float64(v.Stats.DiskQuota)),
+					MemUsage:  (float64(v.Stats.Usage.Mem) / float64(v.Stats.MemQuota)),
 				},
 			},
 		}


### PR DESCRIPTION
Fixes #3.

Internal representations should not be part of our external API. A data
format *is* an API.