### PR TITLE
Add support for whitelisting apps

### DIFF
--- a/src/cf-metrics/main.go
+++ b/src/cf-metrics/main.go
@@ -85,10 +85,12 @@ type Event struct {
 
 func main() {
 	var (
-		verbose bool
+		verbose   bool
+		whitelist string
 	)
 
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
+	flag.StringVar(&whitelist, "whitelist", "", "A comma-separated list of app names to collect data about. If none specified, then defaults to all apps that the account can view.")
 
 	flag.Usage = func() {
 		basename := filepath.Base(os.Args[0])
@@ -125,7 +127,7 @@ func main() {
 
 	logger := trace.NewLogger(writer, verbose, os.Getenv("CF_TRACE"), "")
 
-	spawnWorkers(zones, metrics, events, writer, logger)
+	spawnWorkers(zones, whitelist, metrics, events, writer, logger)
 
 	go func() {
 		for e := range events {

--- a/src/cf-metrics/workers.go
+++ b/src/cf-metrics/workers.go
@@ -9,8 +9,8 @@ import (
 	"code.cloudfoundry.org/cli/cf/trace"
 )
 
-func spawnWorkers(cfInfos []CFInfo, metrics chan AppMetrics, events chan Event, writer io.Writer, logger trace.Printer) {
-	zones := NewZones(cfInfos, writer, logger)
+func spawnWorkers(cfInfos []CFInfo, whitelist string, metrics chan AppMetrics, events chan Event, writer io.Writer, logger trace.Printer) {
+	zones := NewZones(cfInfos, whitelist, writer, logger)
 
 	for _, each := range zones {
 		zone := each
@@ -87,6 +87,9 @@ func readAppsLoop(zone *Zone, metrics chan AppMetrics, events chan Event) {
 func pollApps(zone *Zone, since time.Time, metrics chan AppMetrics, events chan Event) {
 	now := time.Now()
 	err := zone.appRepo.ListApps(func(app models.Application) bool {
+		if !zone.IncludesApp(app.Name) {
+			return true
+		}
 		if app.State == models.ApplicationStateStarted {
 			go fetchStats(app, zone, metrics, now)
 		}


### PR DESCRIPTION
Fixes #4.

Some log aggregators charge per byte ingested. To optimise our costs, we
can opt to filter which apps we are interested in.

Also saves on network traffic and unnecessary API calls to Cloud Foundry
providers.