### PR TITLE
Remove hyphens from JSON field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,53 +52,53 @@ For each application, these will be emitted as:
   "stats":{
     "0":{
       "stats":{
-        "disk-quota":536870912,
-        "mem-quota":402653184,
+        "diskQuota":536870912,
+        "memQuota":402653184,
         "usage":{
           "cpu":0.006985241502010499,
           "disk":186060800,
           "mem":338554880,
-          "disk-usage":0.346565247,
-          "mem-usage":0.84081014
+          "diskUsage":0.346565247,
+          "memUsage":0.84081014
         }
       }
     },
     "1":{
       "stats":{
-        "disk-quota":536870912,
-        "mem-quota":402653184,
+        "diskQuota":536870912,
+        "memQuota":402653184,
         "usage":{
           "cpu":0.007506122659531552,
           "disk":186060800,
           "mem":256016384,
-          "disk-usage":0.34656524658203,
-          "mem-usage":0.63582356770833
+          "diskUsage":0.34656524658203,
+          "memUsage":0.63582356770833
         }
       }
     },
     "2":{
       "stats":{
-        "disk-quota":536870912,
-        "mem-quota":402653184,
+        "diskQuota":536870912,
+        "memQuota":402653184,
         "usage":{
           "cpu":0.004021443931726263,
           "disk":186056704,
           "mem":317755392,
-          "disk-usage":0.3465576171875,
-          "mem-usage":0.78915405273438
+          "diskUsage":0.3465576171875,
+          "memUsage":0.78915405273438
         }
       }
     },
     "3":{
       "stats":{
-        "disk-quota":536870912,
-        "mem-quota":402653184,
+        "diskQuota":536870912,
+        "memQuota":402653184,
         "usage":{
           "cpu":0.00431447831668318,
           "disk":186073088,
           "mem":250630144,
-          "disk-usage":0.34658813476563,
-          "mem-usage":0.62244669596354
+          "diskUsage":0.34658813476563,
+          "memUsage":0.62244669596354
         }
       }
     }
@@ -122,7 +122,7 @@ For each application, these events will be emitted as:
   "app":"hello-python-web",
   "type":"event",
   "timestamp":"2016-11-09T11:49:53.575738294Z",
-  "EventInfo":{
+  "eventInfo":{
     "type":"app.crash",
     "timestamp":"2016-09-20T16:21:29Z"
   }

--- a/src/cf-metrics/main.go
+++ b/src/cf-metrics/main.go
@@ -66,15 +66,15 @@ type Usage struct {
 	CPU       float64 `json:"cpu"`
 	Disk      int64   `json:"disk"`
 	Mem       int64   `json:"mem"`
-	DiskUsage float64 `json:"disk-usage"`
-	MemUsage  float64 `json:"mem-usage"`
+	DiskUsage float64 `json:"diskUsage"`
+	MemUsage  float64 `json:"memUsage"`
 }
 
 // ContainerStats is a fragment that represents instance-level statistics for an
 // application.
 type ContainerStats struct {
-	DiskQuota int64 `json:"disk-quota"`
-	MemQuota  int64 `json:"mem-quota"`
+	DiskQuota int64 `json:"diskQuota"`
+	MemQuota  int64 `json:"memQuota"`
 	Usage     Usage `json:"usage"`
 }
 
@@ -99,7 +99,7 @@ type EventInfo struct {
 // Event is a document that represents a single event for an application.
 type Event struct {
 	Metric
-	EventInfo EventInfo `json:"event-info"`
+	EventInfo EventInfo `json:"eventInfo"`
 }
 
 func main() {


### PR DESCRIPTION
Prefer snakeCase, as per Google JSON guidelines.

We had to jump through some hoops with our current aggregation tool.
Removing it for now.