### PR TITLE
Remove duplicate app invocation in `manifest.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ starting with a manifest like:
 applications:
 - name: worker-app
   buildpack: https://github.com/cloudfoundry/binary-buildpack.git
-  command: chmod +x cf-metrics-linux-amd64 && ./cf-metrics-linux-amd64 -whitelist app1,app2 || ./cf-metrics-linux-amd64 -whitelist app1,app2
+  command: chmod +x cf-metrics-linux-amd64; exec ./cf-metrics-linux-amd64 -whitelist app1,app2
   no-route: true
   health-check-type: none
   memory: 64M


### PR DESCRIPTION
I'm /pretty/ sure you don't need that `&&+||` structure in the manifest.
I think this does what you need, unless I'm missing some subtlety!

The additional `exec` will replace the parent shell process, saving oooooooh several kilobytes of RAMs ...

Fixes #10 